### PR TITLE
Add signal handler for SIGHUP

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -302,6 +302,9 @@ int run_client(const char *peer_addr_pair)
 		struct timeval __current, timeo;
 		int rc;
 
+		if(true==about_to_exit)
+			break;
+
 		FD_ZERO(&rset);
 		FD_SET(state.tunfd, &rset);
 		if (state.sockfd >= 0)

--- a/src/library.c
+++ b/src/library.c
@@ -18,6 +18,8 @@
 
 #include "library.h"
 
+bool about_to_exit=false;
+
 struct name_cipher_pair cipher_pairs[] = {
 	{ "aes-128", EVP_aes_128_cbc, },
 	{ "aes-256", EVP_aes_256_cbc, },
@@ -378,5 +380,11 @@ void do_daemonize(void)
 
 	/* OK, set up the grandchild process */
 	chdir("/tmp");
+}
+
+void  signal_handler(int sig)
+{
+	about_to_exit=true;
+	fprintf(stderr, "minivtun: about to exit, sig=%d\n",sig);
 }
 

--- a/src/library.h
+++ b/src/library.h
@@ -25,6 +25,8 @@ typedef char bool;
 #define true 1
 #define false 0
 
+extern bool about_to_exit;
+
 #define countof(arr) (sizeof(arr) / sizeof((arr)[0]))
 
 #define container_of(ptr, type, member) ({			\
@@ -202,6 +204,8 @@ static inline void hexdump(void *d, size_t len)
 }
 
 void do_daemonize(void);
+
+void  signal_handler(int sig);
 
 #endif /* __LIBRARY_H */
 

--- a/src/minivtun.c
+++ b/src/minivtun.c
@@ -215,6 +215,8 @@ int main(int argc, char *argv[])
 		{ 0, 0, 0, 0, },
 	};
 
+	signal(SIGHUP, signal_handler);
+
 	while ((opt = getopt_long(argc, argv, "r:l:R:H:a:A:m:k:n:p:e:t:v:M:T:Ddwh",
 			long_opts, NULL)) != -1) {
 		switch (opt) {

--- a/src/server.c
+++ b/src/server.c
@@ -651,6 +651,9 @@ int run_server(const char *loc_addr_pair)
 		struct timeval __current, timeo;
 		int rc;
 
+		if(true==about_to_exit)
+			break;
+
 		FD_ZERO(&rset);
 		FD_SET(state.tunfd, &rset);
 		FD_SET(state.sockfd, &rset);


### PR DESCRIPTION
The procd (OpenWrt 18.06) send SIGHUP to kill the process.

It works fine use ```kill -HUP 12345``` under OpenWrt after this patching.

But I don't know how signals was handled under MacOS/FreeBSD.