### PR TITLE
gcc8 溢出警告

### DIFF
--- a/src/library.c
+++ b/src/library.c
@@ -304,7 +304,7 @@ void ip_addr_add_ipv6(const char *ifname, struct in6_addr *local, int prefix)
 
 void ip_link_set_mtu(const char *ifname, unsigned mtu)
 {
-	char cmd[128];
+	char cmd[200];
 #if defined(__APPLE__) || defined(__FreeBSD__)
 	sprintf(cmd, "ifconfig %s mtu %u", ifname, mtu);
 #else


### PR DESCRIPTION
gcc8编译时，报溢出警告，放到200字节不再报警：
-----
library.c:340:2: note: ‘sprintf’ output 28 or more bytes (assuming 130) into a destination of size 128
  sprintf(cmd, "%s route add %s/%d dev %s metric %d%s",
    af == AF_INET6 ? "ip -6" : "ip", __net, prefix,
    ifname, metric, __ip_sfx);
-----